### PR TITLE
Make certAlias Configurable

### DIFF
--- a/src/main/java/cloud/orbit/web/EmbeddedJettyServer.java
+++ b/src/main/java/cloud/orbit/web/EmbeddedJettyServer.java
@@ -132,6 +132,9 @@ public class EmbeddedJettyServer implements Startable
     @Config("orbit.jetty.ssl.protocols.exclude")
     private List<String> sslExcludedProtocols = null;
 
+    @Config("orbit.jetty.ssl.certAlias")
+    private String certAlias = null;
+
 
     @Override
     public Task start()
@@ -243,6 +246,11 @@ public class EmbeddedJettyServer implements Startable
             {
                 sslContextFactory.setExcludeProtocols(sslExcludedProtocols.toArray(new String[sslExcludedProtocols.size()]));
             }
+            if (certAlias != null)
+            {
+                sslContextFactory.setCertAlias(certAlias);
+            }
+
             final HttpConfiguration httpsConfiguration = new HttpConfiguration(httpConfiguration);
             httpsConfiguration.addCustomizer(new SecureRequestCustomizer());
             // SSL connector


### PR DESCRIPTION
For services that contain multiple certificates in the keystore, this configuration is required so that the jetty server knows which certificate to use for the server.

New configuration key: `orbit.jetty.ssl.certAlias`